### PR TITLE
Provision option to skip specific checkov ID

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -12,6 +12,11 @@ on:
         type: string
         default: main
         required: false
+      checkov_skip_check:
+        description: Skip a specific check_id. Can be comma separated list.
+        type: string
+        default: ""
+        required: false
     secrets:
       TFE_TOKEN:
         description: Terraform Cloud Token
@@ -102,6 +107,7 @@ jobs:
         uses: bridgecrewio/checkov-action@master
         with:
           output_format: sarif
+          skip_check : ${{ inputs.checkov_skip_check }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v1
         with:


### PR DESCRIPTION
@lawliet89 @niroz89 

For the openapi spec, we could not able to add the inline skip rule. Created the issue https://github.com/bridgecrewio/checkov/issues/2953

So in the meantime, added the option to skip a specific rule.