### PR TITLE
Fix after actionlint and make sure to change case

### DIFF
--- a/.github/workflows/prisma.yaml
+++ b/.github/workflows/prisma.yaml
@@ -50,9 +50,9 @@ jobs:
       - name: Setup image tag
         run: |
           if [[ -z "${{ inputs.image_tag }}" ]]; then
-            echo "IMAGE_TAG=$(echo "${{ github.repository }}" | awk -F "/" "{print $2}"):${GITHUB_SHA::8}" >> "${GITHUB_ENV}"
+            echo "IMAGE_TAG=$(echo "${{ github.repository }}" | awk -F "/" "{print \$2}" | tr "[:upper:]" "[:lower:]"):${GITHUB_SHA::8}" >> "${GITHUB_ENV}"
           else
-            echo "IMAGE_TAG=${{ inputs.image_tag }}" >> "${GITHUB_ENV}"
+            echo "IMAGE_TAG=$(echo "${{ inputs.image_tag }}" | tr "[:upper:]" "[:lower:]")" >> "${GITHUB_ENV}"
           fi
         shell: bash
 


### PR DESCRIPTION
Expected: `--tag newshub-bh:5e32e025`
Current: `--tag SPHTech/newshub-bh:cf8b5557`

Error: `failed to parse SPHTech/newshub-bh:cf8b5557: invalid reference format: repository name must be lowercase`

Fix: awk with double quote, have to escape `$2` and make sure to change case.

