### PR TITLE
Updates to Terraform precommit

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+          
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Precommit Skips
         id: precommit_skips
         run: |
-          SKIPS="terraform_tflint,markdown-link-check,terraform_docs,terraform_tfsec,checkov"
+          SKIPS="terraform_tflint,markdown-link-check,terraform_docs,terraform_tfsec,terraform_checkov"
           if [ "${branch}" == "${main_branch}"  ];then
               SKIPS="${SKIPS},no-commit-to-branch"
           fi

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -33,9 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
-
-      - run: git fetch --depth=1 origin +${{github.base_ref}}
+          fetch-depth: 1
 
       - uses: actions/setup-python@v2
         with:
@@ -47,7 +45,7 @@ jobs:
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-          
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
@@ -86,7 +84,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
@@ -127,7 +125,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run tfsec with reviewdog output on the PR
         uses: reviewdog/action-tfsec@master

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -41,9 +41,7 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Make Terraform Plugin Cache
-        run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
-
+      - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
         uses: actions/cache@v2
         with:
@@ -61,7 +59,7 @@ jobs:
       - name: Precommit Skips
         id: precommit_skips
         run: |
-          SKIPS="terraform_tflint,markdown-link-check,terraform_docs,terraform_tfsec,terraform_checkov"
+          SKIPS="tflint,terraform_tflint,markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
           if [ "${branch}" == "${main_branch}"  ];then
               SKIPS="${SKIPS},no-commit-to-branch"
           fi
@@ -89,8 +87,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Make Terraform Plugin Cache
-        run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+      - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
         uses: actions/cache@v2
         with:
@@ -106,8 +103,8 @@ jobs:
       - name: Terraform init
         run: terraform init
 
-      - uses: actions/cache@v2
-        name: Cache plugin dir
+      - name: Cache TFlint
+        uses: actions/cache@v2
         with:
           path: ~/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -21,37 +21,47 @@ on:
       TFE_TOKEN:
         description: Terraform Cloud Token
         required: false
+env:
+  TF_PLUGIN_CACHE_DIR: "~/.terraform.d/plugin-cache"
+  TF_IN_AUTOMATION: "true"
 
 jobs:
   fmt-validate:
     name: Format and Validate
     runs-on: ubuntu-latest
-    env:
-      TF_PLUGIN_CACHE_DIR: "/home/runner/.terraform.d/plugin-cache"
-      TF_IN_AUTOMATION: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - run: git fetch --depth=1 origin +${{github.base_ref}}
+
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
       - name: Make Terraform Plugin Cache
-        run: |
-          mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+        run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+
+      - name: Cache Terraform
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: latest
           cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
+
       - name: Terraform init
         run: terraform init
+
       - name: Precommit Skips
         id: precommit_skips
         run: |
-          SKIPS="tflint,markdown-link-check,terraform_docs,terraform_tfsec,checkov"
+          SKIPS="terraform_tflint,markdown-link-check,terraform_docs,terraform_tfsec,checkov"
           if [ "${branch}" == "${main_branch}"  ];then
               SKIPS="${SKIPS},no-commit-to-branch"
           fi
@@ -60,6 +70,7 @@ jobs:
         env:
           branch: ${{ github.ref_name }}
           main_branch: ${{ inputs.main_branch }}
+
       - name: precommit run hooks
         uses: pre-commit/action@v2.0.3
         env:
@@ -68,27 +79,39 @@ jobs:
           extra_args: --color=always --show-diff-on-failure --all-files
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: terraform -v
+
   lint:
     name: Linting
     runs-on: ubuntu-latest
-    env:
-      TF_PLUGIN_CACHE_DIR: "/home/runner/.terraform.d/plugin-cache"
-      TF_IN_AUTOMATION: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Make Terraform Plugin Cache
-        run: |
-          mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+        run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+      - name: Cache Terraform
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: latest
           cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
+
       - name: Terraform init
         run: terraform init
+
+      - uses: actions/cache@v2
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
       - name: Run tflint with review comment on PR
         uses: reviewdog/action-tflint@master
         with:
@@ -98,20 +121,16 @@ jobs:
           reporter: github-pr-review
           # tflint_rulesets: "aws"
           flags: --module
+  
   security:
     name: Security Checks
     runs-on: ubuntu-latest
-    env:
-      TF_PLUGIN_CACHE_DIR: "/home/runner/.terraform.d/plugin-cache"
-      TF_IN_AUTOMATION: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Make Terraform Plugin Cache
-        run: |
-          mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+
       - name: Run tfsec with reviewdog output on the PR
         uses: reviewdog/action-tfsec@master
         with:


### PR DESCRIPTION
- [x] Caching for terraform / TFlint fixed
- [x] Use depth 1 ( which is default ) since these jobs do not need tags or history..
- [x] exclude both checkov/terraform_checkov and tflint/terraform_tflint since terragrunt pre-commint and Anton's pre-commit uses different id, in bt-drupal-infra switching to Anton's pre-commit and then slowly migrate all pre-commit.
- [x] Newlines to group and better readability. 

Tested with BT infra.
<img width="1389" alt="image" src="https://user-images.githubusercontent.com/46478191/171612580-858b44a7-2200-4ede-b446-a4564133aef6.png">
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/46478191/171612662-f1e4cf7e-271a-4ea4-9c42-942db84c4334.png">
