### PR TITLE
Add quiet flag for checkov input

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,10 +17,10 @@ on:
         type: string
         default: ""
         required: false
-      checkov_output_format:
-        description: Checkov output format
+      checkov_output_quiet:
+        description: Checkov output to display only failures
         type: string
-        default: "sarif"
+        default: false
         required: false
       enable_submodules:
         description: Flag to enable GitHub submodules.
@@ -161,7 +161,8 @@ jobs:
         id: checkov
         uses: bridgecrewio/checkov-action@master
         with:
-          output_format: ${{ inputs.checkov_output_format }}
+          output_format: sarif
+          quiet: ${{ inputs.checkov_output_quiet }}
           skip_check : ${{ inputs.checkov_skip_check }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,6 +17,11 @@ on:
         type: string
         default: ""
         required: false
+      checkov_output_format:
+        description: Checkov output format
+        type: string
+        default: "sarif"
+        required: false
       enable_submodules:
         description: Flag to enable GitHub submodules.
         type: boolean
@@ -156,7 +161,7 @@ jobs:
         id: checkov
         uses: bridgecrewio/checkov-action@master
         with:
-          output_format: sarif
+          output_format: ${{ inputs.checkov_output_format }}
           skip_check : ${{ inputs.checkov_skip_check }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
# Description:
- Add quiet flag for checkov input
- This is to avoid dumping large output and just display only the failure information
- Also large output ends up in Argument list too long errors.