### PR TITLE
Fix tflint - switch from reviewdog/action-tflint to terraform_tflint

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -158,7 +158,8 @@ jobs:
         id: tflint
         continue-on-error: true
         run: |
-          pre-commit run terraform_tflint --all-files
+          pre-commit run terraform_validate --all-files --args=--module
+          pre-commit run terraform_tflint --all-files --args=--module
 
       - name: Check status code
         run: |
@@ -171,6 +172,7 @@ jobs:
             exit 1
           fi
 
+         #steps.tflint.outcome  check for outcome
   security:
     name: Security Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -160,10 +160,13 @@ jobs:
         run: |
           pre-commit run terraform_tflint --all-files
           echo "return_code=$?" >> "$GITHUB_ENV"
+          echo "testvar=haha" >> "$GITHUB_ENV"
 
       - name: Check status code
         if: success() || failure ()
         run: |
+          echo "$GITHUB_ENV"
+          echo "$testvar"
           tflint_return=${{ env.return_code }}
           echo $tflint_return
           # SKIP_WARN for skipping all warnings

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -46,7 +46,7 @@ env:
   TF_IN_AUTOMATION: "true"
 
 jobs:
-  fmt-validate:
+  fmt-lint-validate:
     name: Format and Validate
     runs-on: ubuntu-latest
     steps:
@@ -67,6 +67,12 @@ jobs:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
 
+      - name: Cache TFlint
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
@@ -82,7 +88,7 @@ jobs:
       - name: Precommit Skips
         id: precommit_skips
         run: |
-          SKIPS="tflint,terraform_tflint,markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
+          SKIPS="markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
           if [ "${branch}" == "${main_branch}" ];then
               SKIPS="${SKIPS},no-commit-to-branch"
           fi
@@ -105,31 +111,40 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: terraform -v
 
-  lint:
-    name: Linting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-          submodules: ${{ inputs.enable_submodules }}
+  # lint:
+  #   name: Linting
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 1
+  #         submodules: ${{ inputs.enable_submodules }}
 
+<<<<<<< HEAD
       - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
         uses: actions/cache@v3
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+=======
+  #     - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+  #     - name: Cache Terraform
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+  #         key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+>>>>>>> bca88fc (Use pre-commit tflint)
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: latest
-          cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
+  #     - name: Setup Terraform
+  #       uses: hashicorp/setup-terraform@v2
+  #       with:
+  #         terraform_version: latest
+  #         cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
 
-      - name: Terraform init
-        run: terraform init
+  #     - name: Terraform init
+  #       run: terraform init
 
       - name: Cache TFlint
         uses: actions/cache@v3
@@ -137,16 +152,16 @@ jobs:
           path: /home/runner/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
 
-      - name: Run tflint with review comment on PR
-        uses: reviewdog/action-tflint@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tflint_init: true
-          filter_mode: "nofilter"
-          reporter: github-pr-review
-          # tflint_rulesets: "aws"
-          flags: --module
-          level: info
+  #     - name: Run tflint with review comment on PR
+  #       uses: reviewdog/action-tflint@master
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         tflint_init: true
+  #         filter_mode: "nofilter"
+  #         reporter: github-pr-review
+  #         # tflint_rulesets: "aws"
+  #         flags: --module
+  #         level: info
 
   security:
     name: Security Checks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -158,8 +158,8 @@ jobs:
         id: tflint
         continue-on-error: true
         run: |
-          pre-commit run terraform_validate --all-files --args=--module
-          pre-commit run terraform_tflint --all-files --args=--module
+          pre-commit run terraform_validate --all-files
+          pre-commit run terraform_tflint --all-files
 
       - name: Check status code
         run: |

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -148,7 +148,7 @@ jobs:
           tflint_version: latest
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Installl pre-commit
+      - name: Install pre-commit
         uses: BSFishy/pip-action@v1
         with:
           packages: |
@@ -170,7 +170,7 @@ jobs:
           skip_warn=${{ inputs.skip_tflint_warn }}
           if [ "$tflint_return" -eq 0 ]; then
             echo "TFLint correctly returned failure: ${tflint_return}"
-          elif [ $skip_warn ] && [ $tflint_return -eq 2 ]; then
+          elif [ "$skip_warn" ] && [ "$tflint_return" -eq 2 ]; then
             echo "TFLint warnings found and skipped."
           else
             echo "TFLint returned ${reviewdog_return}, expected '0'. Failing..."

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -47,7 +47,7 @@ env:
 
 jobs:
   fmt-lint-validate:
-    name: Format and Validate
+    name: Format, Lint and Validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -67,17 +67,22 @@ jobs:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: latest
+          cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
+
       - name: Cache TFlint
         uses: actions/cache@v2
         with:
           path: /home/runner/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v2
         with:
-          terraform_version: latest
-          cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
+          tflint_version: latest
 
       - name: Pre-init Hook
         run: ${{ inputs.pre_init_hook }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -161,7 +161,6 @@ jobs:
           pre-commit run terraform_tflint --all-files
 
       - name: Check status code
-        if:  ${{ failure() }}
         run: |
           # SKIP_WARN for skipping all warnings
           skip_warn="${{ inputs.skip_tflint_warn }}"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -101,6 +101,10 @@ jobs:
         env:
           branch: ${{ github.ref_name }}
           main_branch: ${{ inputs.main_branch }}
+      - name: precommit clean
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: clean
 
       - name: precommit run hooks
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -180,7 +180,7 @@ jobs:
           if [ "$skip_warn" = true ]; then
             echo "TFLint warnings and errors found and skipped."
           else
-            echo "TFLint errors found, expected '0'. Failing..."
+            echo "TFLint errors found, expected '0'. Failing... To enable skipping please set 'skip_tflint_warn' to true in workflow file"
             exit 1
           fi
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -162,6 +162,7 @@ jobs:
           exit_code=$?
           echo "test"
           echo $exit_code
+          echo "{return-code}={0}" >> "$GITHUB_OUTPUT"
           echo "{return-code}={$exit_code}" >> "$GITHUB_OUTPUT"
 
       - name: Check status code

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -168,9 +168,9 @@ jobs:
           tflint_return=${{ steps.tflint.outputs.return-code }}
           # SKIP_WARN for skipping all warnings
           skip_warn=${{ inputs.skip_tflint_warn }}
-          if [ $tflint_return == 0 ]; then # tflint no error
+          if [ $tflint_return -eq 0 ]; then # tflint no error
             echo "TFLint correctly returned failure: ${tflint_return}"
-          elif [ $skip_warn ] && [ $tflint_return == 2 ]; then #tflint has warnings but no error, pass if skip_warn
+          elif [ $skip_warn ] && [ $tflint_return -eq 2 ]; then #tflint has warnings but no error, pass if skip_warn
             echo "TFLint warnings found and skipped."
           else
             echo "TFLint returned ${tflint_return}, expected '0'. Failing..."

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -153,7 +153,8 @@ jobs:
         run: |
           pre-commit run terraform_tflint --all-files
           exit_code=$?
-          echo "::set-output name=return-code::${tflint_return}"
+          echo "$exit_code"
+          echo "{return-code}=${tflint_return}" >> "$GITHUB_OUTPUT"
 
       - name: Check status code
         if: success() || failure ()
@@ -162,7 +163,7 @@ jobs:
           skip_warn=${{ inputs.skip_tflint_warn }}
           if [ "$tflint_return" -eq 0 ]; then
             echo "TFLint correctly returned failure: ${tflint_return}"
-          elif [ $skip_warn && $tflint_return -eq 2 ]; then
+          elif [ $skip_warn ] && [ $tflint_return -eq 2 ]; then
             echo "TFLint warnings found and skipped."
           else
             echo "TFLint returned ${reviewdog_return}, expected '0'. Failing..."

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -165,7 +165,7 @@ jobs:
           echo "test"
           echo $exit_code
           echo "{return-code}={0}" >> "$GITHUB_OUTPUT"
-          echo "{return-code}={$exit_code}" >> "$GITHUB_OUTPUT"
+          # echo "{return-code}={$exit_code}" >> "$GITHUB_OUTPUT"
 
       - name: Check status code
         if: success() || failure ()

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -164,7 +164,7 @@ jobs:
         run: |
           # SKIP_WARN for skipping all warnings
           skip_warn="${{ inputs.skip_tflint_warn }}"
-          if [ "$skip_warn" ]; then
+          if [ "$skip_warn" = true ]; then
             echo "TFLint warnings and errors found and skipped."
           else
             echo "TFLint errors found, expected '0'. Failing..."

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -101,10 +101,6 @@ jobs:
         env:
           branch: ${{ github.ref_name }}
           main_branch: ${{ inputs.main_branch }}
-      - name: precommit clean
-        uses: pre-commit/action@v2.0.3
-        with:
-          extra_args: --clean
 
       - name: precommit run hooks
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -148,6 +148,12 @@ jobs:
           tflint_version: latest
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Installl pre-commit
+        uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            pre-commit
+
       - name: Run TFLint
         id: tflint
         continue-on-error: true

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: Precommit Skips
         id: precommit_skips
         run: |
-          SKIPS="shellcheck,terraform_validate,terraform_fmt,markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
+          SKIPS="shellcheck,terraform_fmt,markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
           if [ "${branch}" == "${main_branch}" ];then
               SKIPS="${SKIPS},no-commit-to-branch"
           fi

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -158,9 +158,9 @@ jobs:
         id: tflint
         continue-on-error: true
         run: |
-          echo "testvar=haha" >> "$GITHUB_ENV"
           pre-commit run terraform_tflint --all-files
-          echo "return_code=$?" >> "$GITHUB_ENV"
+          exit_code=$?
+          echo "return_code=$exit_code" >> "$GITHUB_ENV"
           echo "testvar=haha" >> "$GITHUB_ENV"
 
       - name: Check status code

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: precommit clean
         uses: pre-commit/action@v2.0.3
         with:
-          extra_args: clean
+          extra_args: --clean
 
       - name: precommit run hooks
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -146,6 +146,7 @@ jobs:
           reporter: github-pr-review
           # tflint_rulesets: "aws"
           flags: --module
+          level: info
 
   security:
     name: Security Checks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -158,7 +158,9 @@ jobs:
         id: tflint
         continue-on-error: true
         run: |
+          terraform init
           pre-commit run terraform_tflint --all-files
+          # it exits here and never use it
           exit_code=$?
           echo "test"
           echo $exit_code

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -147,11 +147,14 @@ jobs:
           tflint_version: latest
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pre-commit
-        uses: BSFishy/pip-action@v1
-        with:
-          packages: |
-            pre-commit
+      # - name: Install pre-commit
+      #   uses: BSFishy/pip-action@v1
+      #   with:
+      #     packages: |
+      #       pre-commit
+
+      - name: Init TFLint
+        run: tflint --init
 
       - name: Run TFLint
         id: tflint

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -37,6 +37,10 @@ on:
         type: string
         default: ""
         required: false
+      skip_tflint_warn:
+        description: Do not fail for tflint warning
+        type: boolean
+        default: false
     secrets:
       TFE_TOKEN:
         description: Terraform Cloud Token
@@ -46,8 +50,8 @@ env:
   TF_IN_AUTOMATION: "true"
 
 jobs:
-  fmt-lint-validate:
-    name: Format, Lint and Validate
+  fmt-validate:
+    name: Format and Validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -73,17 +77,6 @@ jobs:
           terraform_version: latest
           cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
 
-      - name: Cache TFlint
-        uses: actions/cache@v2
-        with:
-          path: /home/runner/.tflint.d/plugins
-          key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
-
-      - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v2
-        with:
-          tflint_version: latest
-
       - name: Pre-init Hook
         run: ${{ inputs.pre_init_hook }}
 
@@ -93,7 +86,7 @@ jobs:
       - name: Precommit Skips
         id: precommit_skips
         run: |
-          SKIPS="markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
+          SKIPS="tflint,terraform_tflint,markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
           if [ "${branch}" == "${main_branch}" ];then
               SKIPS="${SKIPS},no-commit-to-branch"
           fi
@@ -116,40 +109,32 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: terraform -v
 
-  # lint:
-  #   name: Linting
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 1
-  #         submodules: ${{ inputs.enable_submodules }}
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          submodules: ${{ inputs.enable_submodules }}
 
-<<<<<<< HEAD
+
       - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
         uses: actions/cache@v3
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-=======
-  #     - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
-  #     - name: Cache Terraform
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-  #         key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
->>>>>>> bca88fc (Use pre-commit tflint)
 
-  #     - name: Setup Terraform
-  #       uses: hashicorp/setup-terraform@v2
-  #       with:
-  #         terraform_version: latest
-  #         cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: latest
+          cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
 
-  #     - name: Terraform init
-  #       run: terraform init
+      - name: Terraform init
+        run: terraform init
 
       - name: Cache TFlint
         uses: actions/cache@v3
@@ -157,16 +142,32 @@ jobs:
           path: /home/runner/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
 
-  #     - name: Run tflint with review comment on PR
-  #       uses: reviewdog/action-tflint@master
-  #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         tflint_init: true
-  #         filter_mode: "nofilter"
-  #         reporter: github-pr-review
-  #         # tflint_rulesets: "aws"
-  #         flags: --module
-  #         level: info
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v2
+        with:
+          tflint_version: latest
+
+      - name: Run TFLint
+        id: tflint
+        continue-on-error: true
+        run: |
+          pre-commit run terraform_tflint --all-files
+          exit_code=$?
+          echo "::set-output name=return-code::${tflint_return}"
+
+      - name: Check status code
+        if: success() || failure ()
+        run: |
+          tflint_return=${{ steps.tflint.outputs.return-code }}
+          skip_warn=${{ inputs.skip_tflint_warn }}
+          if [ "$tflint_return" -eq 0 ]; then
+            echo "TFLint correctly returned failure: ${tflint_return}"
+          elif [ $skip_warn && $tflint_return -eq 2 ]; then
+            echo "TFLint warnings found and skipped."
+          else
+            echo "TFLint returned ${reviewdog_return}, expected '0'. Failing..."
+            exit 1
+          fi
 
   security:
     name: Security Checks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -159,7 +159,7 @@ jobs:
         run: |
           # echo "testvar=haha" >> "$GITHUB_ENV"
           # pre-commit run terraform_tflint --all-files
-          tflint "$(git diff --name-only)"
+          tflint "$(git diff --name-only main)"
           exit_code=$?
           echo "after tflint"
           echo "return_code=$exit_code" >> "$GITHUB_ENV"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -146,6 +146,7 @@ jobs:
         uses: terraform-linters/setup-tflint@v2
         with:
           tflint_version: latest
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TFLint
         id: tflint

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -159,7 +159,7 @@ jobs:
         run: |
           # echo "testvar=haha" >> "$GITHUB_ENV"
           # pre-commit run terraform_tflint --all-files
-          tflint "$(git diff --name-only main)"
+          tflint $(git diff --name-only "$GITHUB_BASE_REF" "$GITHUB_HEAD_REF")
           exit_code=$?
           echo "after tflint"
           echo "return_code=$exit_code" >> "$GITHUB_ENV"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -167,13 +167,12 @@ jobs:
 
       - name: precommit run tflint hooks
         uses: pre-commit/action@v3.0.0
+        continue-on-error: true
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
         with:
           extra_args: --color=always --show-diff-on-failure --all-files
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: terraform -v
 
       - name: Check status code
         run: |

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -173,7 +173,7 @@ jobs:
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
         with:
-          extra_args: --color=always --show-diff-on-failure
+          extra_args: --color=always --show-diff-on-failure --all-files
 
       - name: Check status code
         if: steps.precommit_run_hooks.outcome == 'failure'

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -161,6 +161,7 @@ jobs:
           terraform init
           pre-commit run terraform_tflint --all-files
           # it exits here and never use it
+          echo "hihihihih"
           exit_code=$?
           echo "test"
           echo $exit_code

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -134,9 +134,6 @@ jobs:
           terraform_version: latest
           cli_config_credentials_token: ${{ secrets.TFE_TOKEN }}
 
-      - name: Terraform init
-        run: terraform init
-
       - name: Cache TFlint
         uses: actions/cache@v3
         with:
@@ -146,7 +143,7 @@ jobs:
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v2
         with:
-          tflint_version: latest
+          tflint_version: 0.44.1
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Precommit Skips

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v2
         with:
-          tflint_version: 0.44.1
+          tflint_version: "v0.44.1"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Precommit Skips

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -157,7 +157,7 @@ jobs:
       - name: Run TFLint
         id: tflint
         continue-on-error: true
-        run:
+        run: |
           pre-commit run terraform_tflint --all-files
           echo "return_code=$?" >> "$GITHUB_ENV"
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -162,7 +162,8 @@ jobs:
         run: |
           # echo "testvar=haha" >> "$GITHUB_ENV"
           # pre-commit run terraform_tflint --all-files
-          tflint $(git diff --name-only "$GITHUB_BASE_REF" "$GITHUB_HEAD_REF")
+          git diff --name-only
+          # tflint $(git diff --name-only "$GITHUB_BASE_REF" "$GITHUB_HEAD_REF")
           exit_code=$?
           echo "after tflint"
           echo "return_code=$exit_code" >> "$GITHUB_ENV"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -157,22 +157,14 @@ jobs:
       - name: Run TFLint
         id: tflint
         continue-on-error: true
-        run: |
-          terraform init
+        run:
           pre-commit run terraform_tflint --all-files
-          # it exits here and never use it
-          echo "hihihihih"
-          exit_code=$?
-          echo "test"
-          echo $exit_code
-          echo "{return-code}={0}" >> "$GITHUB_OUTPUT"
-          # echo "{return-code}={$exit_code}" >> "$GITHUB_OUTPUT"
+          echo "return_code=$?" >> "$GITHUB_ENV"
 
       - name: Check status code
         if: success() || failure ()
         run: |
-          tflint_return=${{ steps.tflint.outputs.return-code }}
-          echo "value"
+          tflint_return=${{ env.return_code }}
           echo $tflint_return
           # SKIP_WARN for skipping all warnings
           skip_warn=${{ inputs.skip_tflint_warn }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -101,6 +101,7 @@ jobs:
           main_branch: ${{ inputs.main_branch }}
 
       - name: precommit run hooks
+        id: precommit_run_hooks
         uses: pre-commit/action@v3.0.0
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
@@ -166,6 +167,7 @@ jobs:
           main_branch: ${{ inputs.main_branch }}
 
       - name: precommit run tflint hooks
+        id: precommit_run_hooks
         uses: pre-commit/action@v3.0.0
         continue-on-error: true
         env:
@@ -174,6 +176,7 @@ jobs:
           extra_args: --color=always --show-diff-on-failure
 
       - name: Check status code
+        if: steps.precommit_run_hooks.outcome == 'failure'
         run: |
           # SKIP_WARN for skipping all warnings
           skip_warn="${{ inputs.skip_tflint_warn }}"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -160,12 +160,16 @@ jobs:
         run: |
           pre-commit run terraform_tflint --all-files
           exit_code=$?
-          echo "{return-code}=${exit_code}" >> "$GITHUB_OUTPUT"
+          echo "test"
+          echo $exit_code
+          echo "{return-code}={$exit_code}" >> "$GITHUB_OUTPUT"
 
       - name: Check status code
         if: success() || failure ()
         run: |
           tflint_return=${{ steps.tflint.outputs.return-code }}
+          echo "value"
+          echo $tflint_return
           # SKIP_WARN for skipping all warnings
           skip_warn=${{ inputs.skip_tflint_warn }}
           if [ $tflint_return -eq 0 ]; then # tflint no error

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -171,8 +171,7 @@ jobs:
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
         with:
-          extra_args: --color=always --show-diff-on-failure --all-files
-          token: ${{ secrets.GITHUB_TOKEN }}
+          extra_args: --color=always --show-diff-on-failure
 
       - name: Check status code
         run: |

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -158,6 +158,7 @@ jobs:
         id: tflint
         continue-on-error: true
         run: |
+          echo "testvar=haha" >> "$GITHUB_ENV"
           pre-commit run terraform_tflint --all-files
           echo "return_code=$?" >> "$GITHUB_ENV"
           echo "testvar=haha" >> "$GITHUB_ENV"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -107,6 +107,7 @@ jobs:
         with:
           extra_args: --color=always --show-diff-on-failure --all-files
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: terraform -v
 
   lint:
@@ -118,7 +119,6 @@ jobs:
         with:
           fetch-depth: 1
           submodules: ${{ inputs.enable_submodules }}
-
 
       - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
@@ -148,18 +148,32 @@ jobs:
           tflint_version: latest
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pre-commit
-        uses: BSFishy/pip-action@v1
-        with:
-          packages: |
-            pre-commit
-
-      - name: Run TFLint
-        id: tflint
-        continue-on-error: true
+      - name: Precommit Skips
+        id: precommit_skips
         run: |
-          pre-commit run terraform_validate --all-files
-          pre-commit run terraform_tflint --all-files
+          SKIPS="shellcheck,terraform_validate,terraform_fmt,markdown-link-check,terraform_docs,terraform_tfsec,checkov,terraform_checkov"
+          if [ "${branch}" == "${main_branch}" ];then
+              SKIPS="${SKIPS},no-commit-to-branch"
+          fi
+          if [ "${{inputs.skip_precommit}}" != "" ]; then
+            SKIPS="${SKIPS},${{inputs.skip_precommit}}"
+          fi
+
+          echo "${SKIPS}"
+          echo "skips=${SKIPS}" >> "${GITHUB_OUTPUT}"
+        env:
+          branch: ${{ github.ref_name }}
+          main_branch: ${{ inputs.main_branch }}
+
+      - name: precommit run tflint hooks
+        uses: pre-commit/action@v3.0.0
+        env:
+          SKIP: ${{ steps.precommit_skips.outputs.skips }}
+        with:
+          extra_args: --color=always --show-diff-on-failure --all-files
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: terraform -v
 
       - name: Check status code
         run: |

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -158,7 +158,8 @@ jobs:
         continue-on-error: true
         run: |
           # echo "testvar=haha" >> "$GITHUB_ENV"
-          pre-commit run terraform_tflint --all-files
+          # pre-commit run terraform_tflint --all-files
+          tflint "$(git diff --name-only)"
           exit_code=$?
           echo "after tflint"
           echo "return_code=$exit_code" >> "$GITHUB_ENV"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -161,7 +161,7 @@ jobs:
           pre-commit run terraform_tflint --all-files
 
       - name: Check status code
-        if: failure()
+        if:  ${{ failure() }}
         run: |
           # SKIP_WARN for skipping all warnings
           skip_warn="${{ inputs.skip_tflint_warn }}"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -148,18 +148,18 @@ jobs:
           tflint_version: latest
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Install pre-commit
-      #   uses: BSFishy/pip-action@v1
-      #   with:
-      #     packages: |
-      #       pre-commit
+      - name: Install pre-commit
+        uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            pre-commit
 
       - name: Run TFLint
         id: tflint
         continue-on-error: true
         run: |
           # echo "testvar=haha" >> "$GITHUB_ENV"
-          # pre-commit run terraform_tflint --all-files
+          pre-commit run terraform_tflint --all-files &>/dev/null
           tflint --init
           tflint -f compact
           exit_code=$?

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -160,22 +160,24 @@ jobs:
         run: |
           pre-commit run terraform_tflint --all-files
           exit_code=$?
-          echo "$exit_code"
-          echo "{return-code}=${tflint_return}" >> "$GITHUB_OUTPUT"
+          echo "{return-code}=${exit_code}" >> "$GITHUB_OUTPUT"
 
       - name: Check status code
         if: success() || failure ()
         run: |
           tflint_return=${{ steps.tflint.outputs.return-code }}
+          # SKIP_WARN for skipping all warnings
           skip_warn=${{ inputs.skip_tflint_warn }}
-          if [ "$tflint_return" -eq 0 ]; then
+          if [ $tflint_return == 0 ]; then # tflint no error
             echo "TFLint correctly returned failure: ${tflint_return}"
-          elif [ "$skip_warn" ] && [ "$tflint_return" -eq 2 ]; then
+          elif [ $skip_warn ] && [ $tflint_return == 2 ]; then #tflint has warnings but no error, pass if skip_warn
             echo "TFLint warnings found and skipped."
           else
-            echo "TFLint returned ${reviewdog_return}, expected '0'. Failing..."
+            echo "TFLint returned ${tflint_return}, expected '0'. Failing..."
             exit 1
           fi
+
+          # Exit codes: 0 is pass 1 is error 2 is warning
 
   security:
     name: Security Checks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -119,7 +119,6 @@ jobs:
           fetch-depth: 1
           submodules: ${{ inputs.enable_submodules }}
 
-
       - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
         uses: actions/cache@v3
@@ -159,9 +158,7 @@ jobs:
         continue-on-error: true
         run: |
           # echo "testvar=haha" >> "$GITHUB_ENV"
-          pre-commit run terraform_tflint --all-files &>/dev/null
-          tflint --init
-          tflint -f compact
+          pre-commit run terraform_tflint --all-files
           exit_code=$?
           echo "after tflint"
           echo "return_code=$exit_code" >> "$GITHUB_ENV"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -119,6 +119,7 @@ jobs:
           fetch-depth: 1
           submodules: ${{ inputs.enable_submodules }}
 
+
       - run: mkdir -p "${TF_PLUGIN_CACHE_DIR}"
       - name: Cache Terraform
         uses: actions/cache@v3
@@ -147,47 +148,29 @@ jobs:
           tflint_version: latest
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Install pre-commit
-      #   uses: BSFishy/pip-action@v1
-      #   with:
-      #     packages: |
-      #       pre-commit
-
-      - name: Init TFLint
-        run: tflint --init
+      - name: Install pre-commit
+        uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            pre-commit
 
       - name: Run TFLint
         id: tflint
         continue-on-error: true
         run: |
-          # echo "testvar=haha" >> "$GITHUB_ENV"
-          # pre-commit run terraform_tflint --all-files
-          git diff --name-only
-          # tflint $(git diff --name-only "$GITHUB_BASE_REF" "$GITHUB_HEAD_REF")
-          exit_code=$?
-          echo "after tflint"
-          echo "return_code=$exit_code" >> "$GITHUB_ENV"
-          echo "testvar=haha" >> "$GITHUB_ENV"
+          pre-commit run terraform_tflint --all-files
 
       - name: Check status code
-        if: success() || failure ()
+        if: failure()
         run: |
-          echo "$GITHUB_ENV"
-          echo "$testvar"
-          tflint_return=${{ env.return_code }}
-          echo $tflint_return
           # SKIP_WARN for skipping all warnings
-          skip_warn=${{ inputs.skip_tflint_warn }}
-          if [ $tflint_return -eq 0 ]; then # tflint no error
-            echo "TFLint correctly returned failure: ${tflint_return}"
-          elif [ $skip_warn ] && [ $tflint_return -eq 2 ]; then #tflint has warnings but no error, pass if skip_warn
-            echo "TFLint warnings found and skipped."
+          skip_warn="${{ inputs.skip_tflint_warn }}"
+          if [ "$skip_warn" ]; then
+            echo "TFLint warnings and errors found and skipped."
           else
-            echo "TFLint returned ${tflint_return}, expected '0'. Failing..."
+            echo "TFLint errors found, expected '0'. Failing..."
             exit 1
           fi
-
-          # Exit codes: 0 is pass 1 is error 2 is warning
 
   security:
     name: Security Checks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -148,18 +148,22 @@ jobs:
           tflint_version: latest
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pre-commit
-        uses: BSFishy/pip-action@v1
-        with:
-          packages: |
-            pre-commit
+      # - name: Install pre-commit
+      #   uses: BSFishy/pip-action@v1
+      #   with:
+      #     packages: |
+      #       pre-commit
 
       - name: Run TFLint
         id: tflint
         continue-on-error: true
         run: |
-          pre-commit run terraform_tflint --all-files
+          # echo "testvar=haha" >> "$GITHUB_ENV"
+          # pre-commit run terraform_tflint --all-files
+          tflint --init
+          tflint -f compact
           exit_code=$?
+          echo "after tflint"
           echo "return_code=$exit_code" >> "$GITHUB_ENV"
           echo "testvar=haha" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Support for monorepo is not excellent in the reviewdog design. We need to set the working directory and when there is change to multiple env, have to rewrite to support matrix build.

https://github.com/reviewdog/action-tflint/issues/25

To Do:

- [ ] check on automatic init when run with --modules flag ( https://github.com/antonbabenko/pre-commit-terraform/issues/87 )
- [ ] add options to skip warning
- [ ] clean code

When --modules disabled,
https://github.com/SPHTech/bt-drupal-infra/actions/runs/3145865576/jobs/5113661015
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/46478191/192915176-52bc4957-a730-403a-a587-a7de3a738024.png">

When --modules enabled.
https://github.com/SPHTech/bt-drupal-infra/actions/runs/3145560001/jobs/5113420619
<img width="840" alt="image" src="https://user-images.githubusercontent.com/46478191/192915240-82d92397-38f2-4041-8495-e0906ef98a84.png">

