### PR TITLE
Make checkov_output quiet by default

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -20,7 +20,7 @@ on:
       checkov_output_quiet:
         description: Checkov output to display only failures
         type: string
-        default: false
+        default: true
         required: false
       enable_submodules:
         description: Flag to enable GitHub submodules.


### PR DESCRIPTION
@Dineshk77 bro, other workflow also hit the 'Argument list too long', so default setting it quiet.