### PR TITLE
[E360-241] feat: Added build_args to inputs

### DIFF
--- a/.github/workflows/package-creation-ecr.yaml
+++ b/.github/workflows/package-creation-ecr.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         default: true
         required: false
+      build_args:
+        description: "Comma delimited list of build arguments for docker"
+        type: string
+        default: ""
+        required: false
 
 jobs:
   publish-to-ecr:
@@ -70,6 +75,7 @@ jobs:
           REPOSITORY: ${{ inputs.ecr_repository }}
         with:
           context: ${{ inputs.context }}
+          build-args: ${{ inputs.build_args }}
           file: ${{ inputs.file }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}, ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
@@ -82,6 +88,7 @@ jobs:
           REPOSITORY: ${{ inputs.ecr_repository }}
         with:
           context: ${{ inputs.context }}
+          build-args: ${{ inputs.build_args }}
           file: ${{ inputs.file }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/package-creation-ecr.yaml
+++ b/.github/workflows/package-creation-ecr.yaml
@@ -31,7 +31,7 @@ on:
         default: true
         required: false
       build_args:
-        description: "Comma delimited list of build arguments for docker"
+        description: "Multi-line string of build arguments for docker"
         type: string
         default: ""
         required: false


### PR DESCRIPTION
Ticket: https://sph.atlassian.net/browse/E360-241

# Context
Synapse UI requires external arguments to be passed into docker during build time. The reusable workflow package-creation-ecr does not support passing build arguments to its build step.

# What was changed
- Added `build_args` input to package-creation-ecr workflow.
  - build_args is not required, and will default to an empty string if not present.
  - build arguments must be separated on a multi-line string. See example below.
- `build_args` is used in both the mutable and immutable build steps.

# Example
The following snippet will apply your build arguments to the docker build cli command:

```yaml
jobs:
  publish-to-ecr-dev:
    uses: SPHTech-Platform/reusable-workflows/.github/workflows/package-creation-ecr.yaml@main
    with:
      aws_account_region: ${{ replace-with-your-region }}
      iam_role_arn: ${{ replace-with-your-role-arn }}
      ecr_repository: ${{ replace-with-your-ecr-repo-name }}
      build_args: |
        ARG1=a
        ARG2=b
```

The resulting command will look like the following:
`docker build ... --build-arg ARG1=a --build_arg ARG2=b ...`