### PR TITLE
Upgrade tfsec sarif action to silence warning set outputs

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -184,7 +184,7 @@ jobs:
             exit 1
           fi
 
-         #steps.tflint.outcome  check for outcome
+        #steps.tflint.outcome  check for outcome
   security:
     name: Security Checks
     runs-on: ubuntu-latest
@@ -209,7 +209,7 @@ jobs:
         with:
           output_format: sarif
           quiet: ${{ inputs.checkov_output_quiet }}
-          skip_check : ${{ inputs.checkov_skip_check }}
+          skip_check: ${{ inputs.checkov_skip_check }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2
         with:
@@ -218,7 +218,7 @@ jobs:
         if: inputs.upload_sarif
 
       - name: Run tfsec
-        uses: aquasecurity/tfsec-sarif-action@v0.1.0
+        uses: aquasecurity/tfsec-sarif-action@v0.1.4
         with:
           sarif_file: tfsec.sarif
       - name: Upload SARIF file


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7760361/217736989-87cedcd4-6ef6-44ab-918a-3b5de44cb01b.png)
Warning due to set outputs being deprecated