### PR TITLE
Allow usage of both self-hosted and cloud runners on v2

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,7 @@ on:
       default_runner_override_label:
         description: Runner label to point to runners
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted"
       runner_label:
         description: Runner label to point to runners
         type: string

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -42,11 +42,11 @@ on:
         type: boolean
         default: true
       default_runner_override_label:
-        description: Runner label to point to runners
+        description: Change this to self-hosted for using self-hosted runners
         type: string
         default: "ubuntu-latest"
       runner_label:
-        description: Runner label to point to runners
+        description: Runner label to point to self hosted runners
         type: string
         default: "ubuntu-latest"
     secrets:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -116,7 +116,7 @@ jobs:
   lint:
     name: Linting
     runs-on:
-      - self-hosted
+      - ubuntu-latest
       - ${{ inputs.runner_label }}
     steps:
       - name: Checkout

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,7 @@ on:
       default_runner_override_label:
         description: Runner label to point to runners
         type: string
-        default: "self-hosted"
+        default: "ubuntu-latest"
       runner_label:
         description: Runner label to point to runners
         type: string

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -41,6 +41,10 @@ on:
         description: Do not fail for tflint warning
         type: boolean
         default: true
+      default_runner_override_label:
+        description: Runner label to point to runners
+        type: string
+        default: "ubuntu-latest"
       runner_label:
         description: Runner label to point to runners
         type: string
@@ -58,7 +62,7 @@ jobs:
   fmt-validate:
     name: Format and Validate
     runs-on:
-      - self-hosted
+      - ${{ inputs.default_runner_override_label }}
       - ${{ inputs.runner_label }}
     steps:
       - name: Checkout
@@ -116,7 +120,7 @@ jobs:
   lint:
     name: Linting
     runs-on:
-      - ubuntu-latest
+      - ${{ inputs.default_runner_override_label }}
       - ${{ inputs.runner_label }}
     steps:
       - name: Checkout
@@ -201,7 +205,7 @@ jobs:
   security:
     name: Security Checks
     runs-on:
-      - self-hosted
+      - ${{ inputs.default_runner_override_label }}
       - ${{ inputs.runner_label }}
     steps:
       - name: Checkout

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,7 @@ on:
       default_runner_override_label:
         description: Change this to self-hosted for using self-hosted runners
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted"
       runner_label:
         description: Runner label to point to self hosted runners
         type: string

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -48,7 +48,7 @@ on:
       runner_label:
         description: Runner label to point to runners
         type: string
-        required: true
+        default: "ubuntu-latest"
     secrets:
       TFE_TOKEN:
         description: Terraform Cloud Token


### PR DESCRIPTION
Previously v2 was locked to only using sefl-hosted runners. This PR allows more flexibility and also a discovery of actually using two `ubuntu-latest` will not lead to the breaking of the workflow