### PR TITLE
Allow pre-commit checks run during PRs and Merge Group event to be just diffs

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -220,6 +220,7 @@ jobs:
 
       - name: precommit run tflint hooks
         id: precommit_run_hooks_all
+        if: inputs.pre_commit_run_all
         uses: pre-commit/action@v3.0.0
         continue-on-error: true
         env:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -135,7 +135,7 @@ jobs:
           then
             pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
           else
-            pre-commit run --from-ref origin/main --to-ref "$GITHUB_SHA" --color=always --show-diff-on-failure
+            pre-commit run --from-ref origin/${{ github.event.repository.default_branch }} --to-ref "$GITHUB_SHA" --color=always --show-diff-on-failure
           fi
 
       - name: precommit run tflint hooks
@@ -225,7 +225,7 @@ jobs:
           then
             pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
           else
-            pre-commit run --from-ref origin/main --to-ref "$GITHUB_SHA" --color=always --show-diff-on-failure
+            pre-commit run --from-ref origin/${{ github.event.repository.default_branch }} --to-ref "$GITHUB_SHA" --color=always --show-diff-on-failure
           fi
 
       - name: precommit run tflint hooks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -223,9 +223,9 @@ jobs:
           git fetch origin
           if [ "$GITHUB_EVENT_NAME" == 'pull_request' ]
           then
-              pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
+            pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
           else
-              pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
+            pre-commit run --from-ref origin/main --to-ref "$GITHUB_SHA" --color=always --show-diff-on-failure
           fi
 
       - name: precommit run tflint hooks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -120,6 +120,17 @@ jobs:
 
       - name: precommit run hooks
         id: precommit_run_hooks
+        if: inputs.pre_commit_run_all == false
+        env:
+          SKIP: ${{ steps.precommit_skips.outputs.skips }}
+        run: |
+          pip install pre-commit
+          git fetch origin
+          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
+
+      - name: precommit run tflint hooks
+        id: precommit_run_hooks_all
+        if: inputs.pre_commit_run_all
         uses: pre-commit/action@v3.0.0
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
@@ -190,6 +201,16 @@ jobs:
         env:
           branch: ${{ github.ref_name }}
           main_branch: ${{ inputs.main_branch }}
+
+      - name: precommit run tflint hooks for only changed files
+        id: precommit_run_hooks
+        if: inputs.pre_commit_run_all == false
+        env:
+          SKIP: ${{ steps.precommit_skips.outputs.skips }}
+        run: |
+          pip install pre-commit
+          git fetch origin
+          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
 
       - name: precommit run tflint hooks
         id: precommit_run_hooks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -135,7 +135,7 @@ jobs:
           then
             pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
           else
-            pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
+            pre-commit run --from-ref origin/main --to-ref "$GITHUB_SHA" --color=always --show-diff-on-failure
           fi
 
       - name: precommit run tflint hooks

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -131,7 +131,12 @@ jobs:
         run: |
           pip install pre-commit
           git fetch origin
-          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha && github.event.pull_request.head.sha || github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
+          if [ "$GITHUB_EVENT_NAME" == 'pull_request' ]
+          then
+            pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
+          else
+            pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
+          fi
 
       - name: precommit run tflint hooks
         id: precommit_run_hooks_all
@@ -216,7 +221,12 @@ jobs:
         run: |
           pip install pre-commit
           git fetch origin
-          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha && github.event.pull_request.head.sha || github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
+          if [ "$GITHUB_EVENT_NAME" == 'pull_request' ]
+          then
+              pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
+          else
+              pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
+          fi
 
       - name: precommit run tflint hooks
         id: precommit_run_hooks_all

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -49,6 +49,10 @@ on:
         description: Runner label to point to self hosted runners
         type: string
         default: "ubuntu-latest"
+      pre_commit_run_all:
+        description: Runner label to point to self hosted runners
+        type: boolean
+        default: false
     secrets:
       TFE_TOKEN:
         description: Terraform Cloud Token
@@ -66,6 +70,7 @@ env:
 
 jobs:
   fmt-validate:
+    if: github.ref_name != 'main'
     name: Format and Validate
     runs-on:
       - ${{ inputs.default_runner_override_label }}
@@ -126,7 +131,7 @@ jobs:
         run: |
           pip install pre-commit
           git fetch origin
-          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
+          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha && github.event.pull_request.head.sha || github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
 
       - name: precommit run tflint hooks
         id: precommit_run_hooks_all
@@ -141,6 +146,7 @@ jobs:
 
   lint:
     name: Linting
+    if: github.ref_name != 'main'
     runs-on:
       - ${{ inputs.default_runner_override_label }}
       - ${{ inputs.runner_label }}
@@ -210,10 +216,10 @@ jobs:
         run: |
           pip install pre-commit
           git fetch origin
-          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha }} --color=always --show-diff-on-failure
+          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha && github.event.pull_request.head.sha || github.event.merge_group.head.sha }} --color=always --show-diff-on-failure
 
       - name: precommit run tflint hooks
-        id: precommit_run_hooks
+        id: precommit_run_hooks_all
         uses: pre-commit/action@v3.0.0
         continue-on-error: true
         env:
@@ -237,6 +243,7 @@ jobs:
         #steps.tflint.outcome  check for outcome
   security:
     name: Security Checks
+    if: github.ref_name != 'main'
     runs-on:
       - ${{ inputs.default_runner_override_label }}
       - ${{ inputs.runner_label }}


### PR DESCRIPTION
Adding of input to control if the workflow does pre-commit for all files or just git diffs of HEAD ref of PR and TARGET ref of PR

For Merge group it takes the default branch of the repo as a destination check and use env var of the triggering SHA to the main branch