### PR TITLE
auth req

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -54,7 +54,7 @@ on:
         type: string
         default: "ubuntu-latest"
       pre_commit_run_all:
-        description: Runner label to point to self hosted runners
+        description: Run pre-commit against all files
         type: boolean
         default: false
     secrets:
@@ -254,6 +254,7 @@ jobs:
         continue-on-error: ${{ inputs.skip_tflint_warn_for_changed_files }}
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip install pre-commit
           git fetch origin


### PR DESCRIPTION
- use self hosted runner on platform for testing (#33)
- Update README.md
- Upgrade tfsec sarif action to silence warning set outputs (#34)
- remove token input (#35)
- Update README.md
- Allow usage of both self-hosted and cloud runners on v2 (#38)
- Make main branch the main branch again and do proper tagging from here (#39)
- add dockerhub token (#41)
- Only run docker login if credentials are provided via secrets (#42)
- Cache TFLint plugins and use authenticated API calls (#43)
- Refactor to run only against changed files (#44)
- Fix merge group (#45)
- Remove mistaken all files (#46)
- revert to working copy (#48)
- Allow pre-commit checks run during PRs and Merge Group event to be just diffs (#50)
- Update terraform.yaml (#51)
- Fix fork PR errors  (#52)
- Update fortify-android.yaml
- Add check for self hosted runners to install nodejs (#53)
- Fix TF lint need node requirement for self hosted runners
- Skip tflint errors by default
- new flag to make sure precommit skipping for changed files are enforced
- Update terraform.yaml
- Add pre-init hook for linting step too
- Update terraform.yaml
- Update terraform.yaml
- use updated secrets for android repo
- Remove actionlint yaml file
- fix secret declaration
- Add trivy scan (#54)
- Add trivy scan (#55)
- remove docker login creds on workflow level
- Use manual init
- shift setup node upwards
- Remove manual init
- add github security alerts issue create in JIRA (#56)
- Add trivy scan (#57)
- update to correct branch name
- update to correct branch name
- PFMENG-843 : Add newrelic deployment marker (#58)
- Add helm install step to terraform ci (#59)
- Add helm install step in ci/linting (#60)
- Enable authenticated req to increase rate limit
