### PR TITLE
Remove tfsec pin

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -323,7 +323,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           flags: -tee
-          tfsec_version: v1.28.1 # This is temporary fix for v1.28.2 bug , to be removed
         if: inputs.upload_sarif != true
 
       - name: Run Checkov action


### PR DESCRIPTION
* workaround introduced in https://github.com/reviewdog/action-tfsec/releases/tag/v1.17.1
* tfsec 1.28.1 also breaks
<img width="948" alt="image" src="https://github.com/SPHTech-Platform/reusable-workflows/assets/46478191/f1e0fb80-d9e9-4f08-a4e1-0ebf496704ce">
