### PR TITLE
Fix trivy scan and update

### DIFF
--- a/.github/workflows/autoupdate-pre-commit.yaml
+++ b/.github/workflows/autoupdate-pre-commit.yaml
@@ -7,7 +7,7 @@ on:
   # on demand
   workflow_dispatch:
 
-# Request from Org admin to allow Github Action workflow to make PR under Settings > Actions > General 
+# Request from Org admin to allow Github Action workflow to make PR under Settings > Actions > General
 permissions:
   actions: read
   checks: read

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on:
-      - ${{ inputs.default_runner_override_label }} 
+      - ${{ inputs.default_runner_override_label }}
       - ${{ inputs.runner_label }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -322,13 +322,13 @@ jobs:
           submodules: ${{ inputs.enable_submodules }}
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@0.19.0
+        uses: aquasecurity/trivy-action@0.20.0
         with:
-          scan-type: 'config'
+          scan-type: 'fs'
           hide-progress: false
           format: 'sarif'
           output: 'trivy-results.sarif'
-          exit-code: '0'
+          exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
 


### PR DESCRIPTION
Fix trivy scan and update
- Included the supported "scan-type" as mentioned in the document. - https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#:~:text=Description-,scan%2Dtype,-String

- Revert exit code to "1" 
- Updated the trivy to 0.20.0
- tested here - https://github.com/SPHTech-EMS/vss-infra/actions/runs/9011875371/job/24760166388?pr=83
