### PR TITLE
fix trivy by reverting the FS scan to Config and remove exit code default to 0

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -324,11 +324,10 @@ jobs:
       - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@0.20.0
         with:
-          scan-type: 'fs'
+          scan-type: 'config'
           hide-progress: false
           format: 'sarif'
           output: 'trivy-results.sarif'
-          exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
 


### PR DESCRIPTION
fix trivy by reverting the FS scan to Config and remove exit code default to 0
- tested with following workflows - 
-  https://github.com/SPHTech-Data/e360-highway-devops/pull/475
- https://github.com/SPHTech-EMS/crsm-commerce-payment-infra/pull/52
