### PR TITLE
[PFMENG-2854] Use enterprise runner for newrelic deployment marker job

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - platform-eng-ent-v2-dual

--- a/.github/workflows/meta.yaml
+++ b/.github/workflows/meta.yaml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: platform-eng-ent-v2-dual
     steps:
       - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1
+        with:
+          actionlint_flags: -config=.github/actionlint.yaml
         if: github.event_name == 'pull_request'
       - name: Check workflow files
         run: |

--- a/.github/workflows/newrelic-deployment.yaml
+++ b/.github/workflows/newrelic-deployment.yaml
@@ -48,7 +48,7 @@ on:
 
 jobs:
     set-deployment-marker:
-        runs-on: ubuntu-latest
+        runs-on: platform-eng-ent-v2-dual
         name: Set newrelic deployment marker
         steps:
         - name: Sets deployment marker


### PR DESCRIPTION
[PFMENG-2854] Use enterprise runner for newrelic deployment marker job

[PFMENG-2854]: https://sph.atlassian.net/browse/PFMENG-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

tested here:
https://github.com/SPHTech/vss-admin-laravel/actions/runs/13542032373/job/37845055176?pr=4696

