### PR TITLE
fix: port EKS plugin cache fixes to v2 branch

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -169,6 +169,7 @@ jobs:
         if: inputs.pre_commit_run_all == false
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
+          TF_PLUGIN_CACHE_DIR: ""
         run: |
           pip install pre-commit
           git fetch origin
@@ -190,6 +191,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
+          TF_PLUGIN_CACHE_DIR: ""
         with:
           extra_args: --color=always --show-diff-on-failure --all-files
 
@@ -284,6 +286,7 @@ jobs:
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TF_PLUGIN_CACHE_DIR: ""
         run: |
           pip install pre-commit
           git fetch origin
@@ -429,6 +432,7 @@ jobs:
         if: inputs.pre_commit_run_all == false
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
+          TF_PLUGIN_CACHE_DIR: ""
         run: |
           pip install pre-commit
           git fetch origin
@@ -450,6 +454,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
+          TF_PLUGIN_CACHE_DIR: ""
         with:
           extra_args: --color=always --show-diff-on-failure --all-files
 
@@ -543,6 +548,7 @@ jobs:
         env:
           SKIP: ${{ steps.precommit_skips.outputs.skips }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TF_PLUGIN_CACHE_DIR: ""
         run: |
           pip install pre-commit
           git fetch origin


### PR DESCRIPTION
This PR adds the `TF_PLUGIN_CACHE_DIR: ""` configuration to the precommit and tflint steps in `.github/workflows/terraform.yaml`. These changes were previously implemented in the `eks` branch to address module cache issues and are now being ported to the `v2` branch to ensure consistency and reliable workflow execution.

**Changes:**
- Added `TF_PLUGIN_CACHE_DIR: ""` to all `precommit` and `tflint` steps in `.github/workflows/terraform.yaml`.
- Applied these changes across both standard and dual-stack runner jobs.